### PR TITLE
Ensure test configuration supports isolation

### DIFF
--- a/instruments/brass/package.json
+++ b/instruments/brass/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "mocha": "^2.3.4",
+    "really-need": "^1.7.2",
     "supertest": "^1.1.0"
   }
 }

--- a/instruments/brass/spec/server-spec.js
+++ b/instruments/brass/spec/server-spec.js
@@ -1,19 +1,26 @@
 var request = require('supertest');
+var reallyRequire = require('really-need');
 
 describe('loading express', function() {
   var server;
 
   beforeEach(function() {
-    server = require('../app/server');
+    server = reallyRequire('../app/server', { bustCache: true });
   });
 
-  afterEach(function() {
-    server.close();
+  afterEach(function(done) {
+    server.close(done);
   });
 
   it('responds to /note', function testNote(done) {
     request(server)
       .get('/note')
       .expect(200, done);
+  });
+
+  it('returns a 404 for an invalid path', function testInvalidPath(done) {
+    request(server)
+      .get('/invalid-path')
+      .expect(404, done);
   });
 });


### PR DESCRIPTION
- Need to pass Mocha's `done` callback to `server.close()` to ensure
  each test correctly closes the server instance that was under test.
  
  Because of node's module system cache this causes subsequent tests
  to load the instance of the server that we closed from the cache.
  
  Loading the server using `really-need` instead of require to
  force cache busting.
  
  Reference: http://bit.ly/1NH1fxN
